### PR TITLE
default anchor : same x,y, and r=0

### DIFF
--- a/labeler.js
+++ b/labeler.js
@@ -248,6 +248,12 @@ d3.labeler = function() {
   // users insert label positions
     if (!arguments.length) return lab;
     lab = x;
+    // default anchor: same x,y, and r=0
+    for (i in lab) {
+      if (typeof anc[i] == 'undefined') {
+        anc[i] = { x: lab[i].x, y: lab[i].y, r:0 };
+      }
+    }
     return labeler;
   };
 

--- a/labeler.js
+++ b/labeler.js
@@ -249,7 +249,7 @@ d3.labeler = function() {
     if (!arguments.length) return lab;
     lab = x;
     // default anchor: same x,y, and r=0
-    for (i in lab) {
+    for (var i in lab) {
       if (typeof anc[i] == 'undefined') {
         anc[i] = { x: lab[i].x, y: lab[i].y, r:0 };
       }


### PR DESCRIPTION
By default, we can say `anchor.x = label.x`, `anchor.y = label.y`, and `anchor.r = 0`.
